### PR TITLE
Add CI workflow and update docs for docker limitations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,43 @@
-name: CI
+name: CI Build & Lint
 
-on:
-  pull_request:
-  push:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        ports: [5432:5432]
+        env:
+          POSTGRES_DB: test_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: 3.12
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-      - name: Run pre-commit
+          cd backend
+          pip install -r requirements.txt
+
+      - name: Run backend tests
         run: |
-          if [ -f .pre-commit-config.yaml ]; then pre-commit run --show-diff-on-failure --all-files; else echo "No pre-commit config"; fi
+          cd backend
+          pytest -q
+
+      - name: Build Docker images
+        run: |
+          docker compose -f infra/docker-compose.yml build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,15 @@ jobs:
           cd backend
           pip install -r requirements.txt
 
+      - name: Install test dependencies
+        run: |
+          cd backend
+          pip install pytest pytest-django pytest-cov
+
       - name: Run backend tests
         run: |
           cd backend
-          pytest -q
+          pytest --cov=. -q
 
       - name: Build Docker images
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,12 @@
 - [Документация React](https://react.dev/)
 - [Руководства по Docker и DevOps](https://docs.docker.com/)
 - [Руководство GitHub Actions](https://docs.github.com/en/actions)
+
+### Ограничения среды Codex
+
+Codex не может выполнять команды `docker` и `docker compose`, но обязан:
+
+- Генерировать корректные `Dockerfile`, `docker-compose.yml`, `.env` и прочие конфигурации
+- Проверять конфигурации синтаксически
+- Отмечать в `BUILD_REPORT.md`, что docker-тесты требуют локального или CI-подтверждения
+- Не имитировать запуск docker-команд — только конфигурация и логика

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -24,3 +24,6 @@ The backend container started successfully, `collectstatic` completed, and the a
    docker compose -f infra/docker-compose.yml up --build
    ```
    The images will be built and services started.
+
+⚠️ Docker-сборка не была протестирована в Codex (docker недоступен в окружении).
+Пожалуйста, запустите `docker compose -f infra/docker-compose.yml build` локально или проверьте GitHub Actions workflow.

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -27,3 +27,8 @@ The backend container started successfully, `collectstatic` completed, and the a
 
 ⚠️ Docker-сборка не была протестирована в Codex (docker недоступен в окружении).
 Пожалуйста, запустите `docker compose -f infra/docker-compose.yml build` локально или проверьте GitHub Actions workflow.
+
+## CI limitations and notes
+
+- Workflow `.github/workflows/ci.yml` устанавливает тестовые зависимости и запускает `pytest --cov=.`.
+- Docker-команды выполняются только в CI или локально при наличии docker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Initial documentation set (`README`, `TECHNICAL_OVERVIEW`, `API_REFERENCE`, `USER_GUIDE`, `DEV_GUIDE`).
 - Starter change log.
 - `STATIC_ROOT` setting with default `/app/static` and documentation on collecting static files.
+- GitHub Actions workflow installs test requirements and runs `pytest --cov=.`.
+
+### Changed
+
+- Updated README and BUILD_REPORT with CI usage notes and limitations.
 
 ## [v0.1.0] - 2024-08-09
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ in your `.env` if you override it.
 
 Collected files will be served from `/static/` when running the stack.
 
+## Docker & CI
+
+Codex не выполняет docker-команды напрямую. Для гарантии сборки используется GitHub Actions:
+
+- `.github/workflows/ci.yml` автоматически проверяет:
+  - Dockerfile и docker-compose.yml
+  - Тесты backend через pytest
+  - Успешную сборку образов
+
+Перед деплоем обязательно убедитесь, что CI пройден без ошибок.
+
 ## Contributing
 
 Contributions are welcome! Please read `AGENTS.md` and follow the coding style guidelines. Run `pre-commit` and tests before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Collected files will be served from `/static/` when running the stack.
 
 Codex не выполняет docker-команды напрямую. Для гарантии сборки используется GitHub Actions:
 
-- `.github/workflows/ci.yml` автоматически проверяет:
-  - Dockerfile и docker-compose.yml
-  - Тесты backend через pytest
-  - Успешную сборку образов
+- `.github/workflows/ci.yml` автоматически:
+  - устанавливает зависимости и пакеты `pytest`, `pytest-django`, `pytest-cov`;
+  - запускает `pytest --cov=.` для backend;
+  - проверяет `Dockerfile` и `docker-compose.yml` на успешную сборку образов.
 
-Перед деплоем обязательно убедитесь, что CI пройден без ошибок.
+Если docker недоступен локально, полагайтесь на результаты CI. Перед деплоем обязательно убедитесь, что workflow завершился без ошибок.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- note docker limitations and instructions in `AGENTS.md`
- clarify CI usage for docker in README
- create CI workflow to run tests and docker build
- mention docker build constraints in BUILD_REPORT

## Testing
- `pre-commit run --files AGENTS.md README.md .github/workflows/ci.yml BUILD_REPORT.md`
- `pip install -r requirements.txt`
- `pytest backend/tests/test_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c4035be48329904bc11d77b9d4e2