### PR TITLE
Improve post editor features

### DIFF
--- a/frontend/src/components/PostForm.tsx
+++ b/frontend/src/components/PostForm.tsx
@@ -16,8 +16,8 @@ const schema = z.object({
   sitemap_include: z.boolean(),
   sitemap_priority: z.number().min(0).max(1),
   sitemap_changefreq: z.string(),
-  meta_description: z.string().optional(),
-  meta_keywords: z.string().optional(),
+  meta_description: z.string().min(1, "Meta description обязателен").max(160),
+  meta_keywords: z.string().min(1, "Meta keywords обязательны").max(160),
   tags: z.array(z.number()),
 });
 
@@ -40,7 +40,7 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
     handleSubmit,
     watch,
     setValue,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, dirtyFields, isSubmitting },
   } = useForm<PostFormData>({
     resolver: zodResolver(schema),
     defaultValues: initialData ?? {
@@ -61,17 +61,21 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
   const [publish, setPublish] = useState(false);
 
   const title = watch("title");
+  const slugValue = watch("slug");
+  const descriptionValue = watch("description");
+  const metaDescriptionValue = watch("meta_description");
+  const metaKeywordsValue = watch("meta_keywords");
   const tags = watch("tags");
   const body = watch("body");
 
   useEffect(() => {
-    if (title) {
+    if (title && !dirtyFields.slug) {
       setValue(
         "slug",
         slugify(title, { lower: true, strict: true, locale: "ru" }),
       );
     }
-  }, [title, setValue]);
+  }, [title, setValue, dirtyFields.slug]);
 
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
@@ -94,6 +98,9 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
       <div>
         <label htmlFor="title" className="block mb-1">
           Заголовок
+          <span className="ml-2 text-sm text-gray-500">
+            {title?.length || 0}/80
+          </span>
         </label>
         <input
           id="title"
@@ -107,6 +114,9 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
       <div>
         <label htmlFor="slug" className="block mb-1">
           Slug
+          <span className="ml-2 text-sm text-gray-500">
+            {slugValue?.length || 0}
+          </span>
         </label>
         <input
           id="slug"
@@ -117,6 +127,9 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
       <div>
         <label htmlFor="description" className="block mb-1">
           Описание
+          <span className="ml-2 text-sm text-gray-500">
+            {descriptionValue?.length || 0}/160
+          </span>
         </label>
         <textarea
           id="description"
@@ -180,7 +193,12 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
         </div>
       </div>
       <div>
-        <label className="block mb-1">Meta description</label>
+        <label className="block mb-1">
+          Meta description
+          <span className="ml-2 text-sm text-gray-500">
+            {metaDescriptionValue?.length || 0}/160
+          </span>
+        </label>
         <textarea
           {...register("meta_description")}
           className="w-full border rounded p-2"
@@ -188,7 +206,12 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
         />
       </div>
       <div>
-        <label className="block mb-1">Meta keywords</label>
+        <label className="block mb-1">
+          Meta keywords
+          <span className="ml-2 text-sm text-gray-500">
+            {metaKeywordsValue?.length || 0}/160
+          </span>
+        </label>
         <input
           type="text"
           {...register("meta_keywords")}
@@ -199,16 +222,18 @@ export default function PostForm({ initialData, allTags, onSubmit }: Props) {
         <button
           type="submit"
           onClick={() => setPublish(false)}
-          className="rounded bg-gray-600 px-4 py-2 text-white"
+          disabled={isSubmitting}
+          className="rounded bg-gray-600 px-4 py-2 text-white disabled:opacity-50"
         >
-          Сохранить черновик
+          {isSubmitting ? "Сохранение..." : "Сохранить черновик"}
         </button>
         <button
           type="submit"
           onClick={() => setPublish(true)}
-          className="rounded bg-blue-600 px-4 py-2 text-white"
+          disabled={isSubmitting}
+          className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
         >
-          Опубликовать
+          {isSubmitting ? "Сохранение..." : "Опубликовать"}
         </button>
       </div>
     </form>

--- a/frontend/src/components/tiptap-editor/index.tsx
+++ b/frontend/src/components/tiptap-editor/index.tsx
@@ -6,7 +6,17 @@ import Link from "@tiptap/extension-link";
 import Underline from "@tiptap/extension-underline";
 import TextAlign from "@tiptap/extension-text-align";
 import { useEffect, useState } from "react";
-import { FaBold, FaItalic, FaImage, FaLink } from "react-icons/fa";
+import {
+  FaBold,
+  FaItalic,
+  FaImage,
+  FaLink,
+  FaHeading,
+  FaListUl,
+  FaListOl,
+  FaQuoteRight,
+  FaCode,
+} from "react-icons/fa";
 import ImageUploader from "../image-uploader";
 
 interface Props {
@@ -67,6 +77,51 @@ export default function TiptapEditor({
         </button>
         <button
           type="button"
+          onClick={() =>
+            editor.chain().focus().toggleHeading({ level: 2 }).run()
+          }
+          className={`p-1 ${
+            editor.isActive("heading", { level: 2 }) ? "bg-gray-200" : ""
+          }`}
+        >
+          <FaHeading />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          className={`p-1 ${
+            editor.isActive("bulletList") ? "bg-gray-200" : ""
+          }`}
+        >
+          <FaListUl />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          className={`p-1 ${
+            editor.isActive("orderedList") ? "bg-gray-200" : ""
+          }`}
+        >
+          <FaListOl />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          className={`p-1 ${
+            editor.isActive("blockquote") ? "bg-gray-200" : ""
+          }`}
+        >
+          <FaQuoteRight />
+        </button>
+        <button
+          type="button"
+          onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+          className={`p-1 ${editor.isActive("codeBlock") ? "bg-gray-200" : ""}`}
+        >
+          <FaCode />
+        </button>
+        <button
+          type="button"
           onClick={() => setShowUploader(true)}
           className="p-1"
         >
@@ -91,7 +146,7 @@ export default function TiptapEditor({
       </div>
       <EditorContent
         editor={editor}
-        className="border rounded p-2 min-h-[200px]"
+        className="border rounded p-2 min-h-[300px] resize-y"
       />
       {showUploader && (
         <div className="mt-2">


### PR DESCRIPTION
## Summary
- extend Tiptap toolbar with extra formatting buttons
- enlarge editor area
- show real-time character counters on form fields
- require meta fields via zod schema
- disable submit buttons while saving

## Testing
- `pre-commit run --files frontend/src/components/PostForm.tsx frontend/src/components/tiptap-editor/index.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68448836fe988329b523649412c38774